### PR TITLE
Use a monospace font.

### DIFF
--- a/fluffy/static/scss/home.scss
+++ b/fluffy/static/scss/home.scss
@@ -202,6 +202,8 @@
             box-sizing: border-box;
             border: solid 1px #efefef;
 
+            font-family: monospace;
+
             padding: 5px;
 
             width: 100%;


### PR DESCRIPTION
The text pasted in Fluffy will mostly be source code or stack traces
etc. Thus, using a monospace font makes sense.