### PR TITLE
Add a json option for paste

### DIFF
--- a/fluffy/views.py
+++ b/fluffy/views.py
@@ -188,4 +188,17 @@ def paste():
 
         upload_objects(objects, metadata_url=metadata_obj.url)
 
-    return redirect(paste_obj.url)
+    if 'json' in request.args:
+        return jsonify({
+            'success': True,
+            'redirect': paste_obj.url,
+            'uploaded_files': {
+                'paste': {
+                    'raw': uf.url,
+                    'paste': paste_obj.url,
+                    'metadata': metadata_obj.url,
+                },
+            },
+        })
+    else:
+        return redirect(paste_obj.url)

--- a/tests/integration/paste_test.py
+++ b/tests/integration/paste_test.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 import requests
 from pyquery import PyQuery as pq
@@ -20,3 +22,27 @@ def test_simple_paste(content, running_server):
         pq(req.content.decode('utf8')).find('input[name=text]').attr('value') ==
         content
     )
+
+
+def test_simple_paste_json(running_server):
+    req = requests.post(
+        running_server['home'] + '/paste?json',
+        data={
+            'text': 'hello world',
+            'language': 'autodetect',
+        },
+    )
+
+    assert req.status_code == 200
+    assert req.headers['Content-Type'] == 'application/json'
+    assert req.json() == {
+        'success': True,
+        'redirect': mock.ANY,
+        'uploaded_files': {
+            'paste': {
+                'raw': mock.ANY,
+                'paste': mock.ANY,
+                'metadata': mock.ANY,
+            },
+        },
+    }


### PR DESCRIPTION
This will help with #46, though we still need CLI support to close that out.

This adds a new JSON API option for pastes. It's intentionally kept nearly identical to the upload API (I'm thinking eventually it would be nice to merge these):

```
$ curl -D- -XPOST -d'text=hello&language=autodetect' http://localhost:5000/paste?json
HTTP/1.0 200 OK
Content-Type: application/json
Content-Length: 376
Server: Werkzeug/0.14.1 Python/3.5.3
Date: Fri, 26 Oct 2018 02:30:29 GMT

{
  "redirect": "https://i.fluffy.cc/c4SxZ5BpSP40kzBvMqTLfPlLfLql6ckc.html",
  "success": true,
  "uploaded_files": {
    "paste": {
      "metadata": "https://i.fluffy.cc/CP909smZlfmwnGhTMN5FnqFVdDb3b4dW.json",
      "paste": "https://i.fluffy.cc/c4SxZ5BpSP40kzBvMqTLfPlLfLql6ckc.html",
      "raw": "https://i.fluffy.cc/hsWv3CZx9N2fXT7hMhK53DSGQ7s6rF9v.txt"
    }
  }
}

```

The `paste` key under `uploaded_files` is a constant that can be depended on when using the paste endpoint. This response has the same shape as the upload JSON response.