### PR TITLE
Add --direct-link option to fput and fpb

### DIFF
--- a/fluffy/views.py
+++ b/fluffy/views.py
@@ -161,8 +161,6 @@ def paste():
             )))
             objects.append(paste_obj)
 
-        print(lang_title)
-
         # Metadata JSON object
         metadata = {
             'server_version': version,

--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -40,6 +40,15 @@ def paste_urls_from_details(details):
     )
 
 
+def raw_text_url_from_paste_html(paste_html):
+    """Return raw text URL from a paste page source."""
+    url, = re.findall(
+        r'<a class="button" href="(http://localhost:\d+/object/[^"]+)">\s+Raw Text',
+        paste_html,
+    )
+    return url
+
+
 def assert_url_matches_content(url, content):
     req = requests.get(url)
     assert req.content == content

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,0 +1,18 @@
+import os
+import sys
+from unittest import mock
+
+import pytest
+
+
+@pytest.yield_fixture
+def cli_on_path():
+    with mock.patch.dict(
+            os.environ,
+            {
+                'PATH': '{}:{}'.format(
+                    os.path.dirname(sys.executable), os.environ['PATH'],
+                ),
+            },
+    ):
+        yield

--- a/tests/cli/paste_test.py
+++ b/tests/cli/paste_test.py
@@ -1,0 +1,53 @@
+import subprocess
+
+import pytest
+import requests
+
+from testing import assert_url_matches_content
+from testing import PLAINTEXT_TESTCASES
+from testing import raw_text_url_from_paste_html
+
+
+@pytest.mark.parametrize('content', PLAINTEXT_TESTCASES)
+@pytest.mark.usefixtures('cli_on_path')
+def test_simple_paste_from_file(content, running_server, tmpdir):
+    path = tmpdir.join('ohai.txt')
+    path.write(content, 'w')
+    info_url = subprocess.check_output(
+        ('fpb', '--server', running_server['home'], path.strpath),
+    ).strip()
+
+    req = requests.get(info_url)
+    assert req.status_code == 200
+    assert_url_matches_content(
+        raw_text_url_from_paste_html(req.text),
+        content.encode('UTF-8'),
+    )
+
+
+@pytest.mark.parametrize('content', PLAINTEXT_TESTCASES)
+@pytest.mark.usefixtures('cli_on_path')
+def test_simple_paste_from_stdin(content, running_server, tmpdir):
+    info_url = subprocess.check_output(
+        ('fpb', '--server', running_server['home']),
+        input=content.encode('UTF-8'),
+    ).strip()
+
+    req = requests.get(info_url)
+    assert req.status_code == 200
+    assert_url_matches_content(
+        raw_text_url_from_paste_html(req.text),
+        content.encode('UTF-8'),
+    )
+
+
+@pytest.mark.usefixtures('cli_on_path')
+def test_paste_with_direct_link(running_server, tmpdir):
+    info_url = subprocess.check_output(
+        ('fpb', '--server', running_server['home'], '--direct-link'),
+        input=b'hello world!',
+    ).strip()
+
+    req = requests.get(info_url)
+    assert req.status_code == 200
+    assert req.text == 'hello world!'


### PR DESCRIPTION
Fixes #46 

Example usage:

```
$ fpb --server http://localhost:5000 --direct-link <<< 'hello'
https://i.fluffy.cc/NVfNrJBwk1n910RPDHhtXV9jCV2CsKsG.txt
```
```
$ fput --server http://localhost:5000 --direct-link fluffy/static/app.css
https://i.fluffy.cc/t6r49kZNLcDDz0B3t8RcMNVq10X53w32.css
```
```
$ fput --server http://localhost:5000 --direct-link fluffy/static/*.css  
https://i.fluffy.cc/PCZxKz2XJsTdCrQCS2C0KdB5CR0Hp113.css
https://i.fluffy.cc/qXq1J7sKNT9P5R9K2ZRK2pTWWT4HkP7C.css
```

These new CLI tools will require a pretty up-to-date server (like, a version of the server I haven't even released yet) since they use `?json` for pastes, which I only added in #69 earlier tonight. I think that's probably okay though, there aren't that many servers and I've never tried to claim the CLIs will be compatible with old servers (only that old CLIs will be compatible with new servers, which is IMO more important).

Also took the opportunity to write some integration tests for both `fpb` and `fput`, which were lacking them before.