### PR TITLE
Add a `--tee` option for `fpb`. Fixes #67

### DIFF
--- a/cli/fluffy_cli/main.py
+++ b/cli/fluffy_cli/main.py
@@ -87,7 +87,7 @@ def paste(server, path, language, highlight_regex, auth, direct_link, tee):
             # We should stream it
             for line in sys.stdin:
                 content += line
-                print(line, end='')  # The line will already have a newline
+                print(line, flush=True, end='')  # The line will already have a newline
         else:
             content = sys.stdin.read()
     else:

--- a/tests/cli/paste_test.py
+++ b/tests/cli/paste_test.py
@@ -51,3 +51,22 @@ def test_paste_with_direct_link(running_server, tmpdir):
     req = requests.get(info_url)
     assert req.status_code == 200
     assert req.text == 'hello world!'
+
+
+@pytest.mark.usefixtures('cli_on_path')
+def test_paste_with_tee(running_server, tmpdir):
+    input_text = b'hello\nworld!'
+    output = subprocess.check_output(
+        ('fpb', '--server', running_server['home'], '--tee'),
+        input=input_text,
+    ).strip()
+
+    assert input_text in output
+    info_url = output.split(b'\n')[-1]
+    req = requests.get(info_url)
+    assert req.status_code == 200
+
+    assert_url_matches_content(
+        raw_text_url_from_paste_html(req.text),
+        input_text,
+    )


### PR DESCRIPTION
Added a unit test. `make test` is green.

Also did some manual verification and regression testing:
```
(venv) dpopes@danielpops:~/dev/fluffy (fpb--tee) [01:48:49] ✗
$ echo "foo" | fpb --tee
foo

---
https://i.fluffy.cc/4GklVW9P1wx4RG6lkxHdfZvbK9mS0F9Q.html
(venv) dpopes@danielpops:~/dev/fluffy (fpb--tee) [01:49:15] ✓
$ printf "foo" | fpb --tee
foo
---
https://i.fluffy.cc/tMVj2t066kfMNGMcLm7klczVv9QNlpRV.html
(venv) dpopes@danielpops:~/dev/fluffy (fpb--tee) [01:49:28] ✓
$ echo "foo" | fpb
https://i.fluffy.cc/KhzMttBCLzlNwMpQDHWfSwLv7ldljwZL.html
```