### PR TITLE
use cryptographically secure randomness for identifiers

### DIFF
--- a/fluffy/utils.py
+++ b/fluffy/utils.py
@@ -10,6 +10,7 @@ ONE_GB = 2**30
 STORED_FILE_NAME_LENGTH = 32
 STORED_FILE_NAME_CHARS = 'bcdfghjklmnpqrstvwxzBCDFGHJKLMNPQRSTVWXZ0123456789'
 
+RNG = random.SystemRandom()
 
 @app.template_filter()
 def pluralize(s, num):
@@ -34,7 +35,7 @@ def human_size(size):
 
 def gen_unique_id():
     return ''.join(
-        random.choice(STORED_FILE_NAME_CHARS)
+        RNG.choice(STORED_FILE_NAME_CHARS)
         for _ in range(STORED_FILE_NAME_LENGTH)
     )
 

--- a/fluffy/utils.py
+++ b/fluffy/utils.py
@@ -12,6 +12,7 @@ STORED_FILE_NAME_CHARS = 'bcdfghjklmnpqrstvwxzBCDFGHJKLMNPQRSTVWXZ0123456789'
 
 RNG = random.SystemRandom()
 
+
 @app.template_filter()
 def pluralize(s, num):
     # very naive


### PR DESCRIPTION
This is mostly just paranoia. But the README does say that identifiers should be "unguessable".

I didn't set up a full dev instance to test this, but I tested the code manually in Pythons 2.7.15rc1 and 3.6.6.