### PR TITLE
Add a separate theme preference for terminal output

### DIFF
--- a/fluffy/component/highlighting.py
+++ b/fluffy/component/highlighting.py
@@ -51,12 +51,18 @@ class PygmentsHighlighter(namedtuple('PygmentsHighlighter', ('lexer',))):
     def name(self):
         return self.lexer.name
 
+    @property
+    def is_terminal_output(self):
+        return 'ansi-color' in self.lexer.aliases
+
     def highlight(self, text):
         text = _highlight(text, self.lexer)
         return text
 
 
-class DiffHighlighter(namedtuple('PygmentsHighlighter', ('lexer',))):
+class DiffHighlighter(namedtuple('DiffHighlighter', ('lexer',))):
+
+    is_terminal_output = False
 
     @property
     def name(self):

--- a/fluffy/templates/layouts/text.html
+++ b/fluffy/templates/layouts/text.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block content %}
-    <div id="highlightContainer" class="highlight-default">
+    <div id="highlightContainer" class="{% block highlight_class %}highlight-default{% endblock %}">
         {% block highlight_start %}{% endblock %}
         <div class="paste-toolbar">
             <div class="info">

--- a/fluffy/templates/paste.html
+++ b/fluffy/templates/paste.html
@@ -1,6 +1,20 @@
 {% set page_name = 'paste' %}
 {% extends 'layouts/text.html' %}
 
+{#
+    Terminal output gets its own preferred theme setting, since many people
+    seem to prefer a dark background for terminal output, but a light
+    background for regular code.
+#}
+{% if highlighter.is_terminal_output %}
+    {% set preferredStyleVar = 'preferredStyleTerminal' %}
+    {% set defaultStyle = 'monokai' %}
+{% else %}
+    {% set preferredStyleVar = 'preferredStyle' %}
+    {% set defaultStyle = 'default' %}
+{% endif %}
+{% block highlight_class %}highlight-{{defaultStyle}}{% endblock %}
+
 {% block extra_head %}
     <link rel="stylesheet" href="{{asset_url('pygments.css')}}" />
 {% endblock %}
@@ -11,10 +25,11 @@
 
 {% block highlight_start %}
     <script>
+        var preferredStyleVar = {{preferredStyleVar|tojson}};
         function changeStyleTo(style) {
             document.getElementById('highlightContainer').className = 'highlight-' + style;
             if (hasStorage) {
-                localStorage.setItem('preferredStyle', style);
+                localStorage.setItem(preferredStyleVar, style);
             }
         }
 
@@ -32,7 +47,7 @@
 
         var preferredStyle = null;
         if (hasStorage) {
-            preferredStyle = localStorage.getItem('preferredStyle');
+            preferredStyle = localStorage.getItem(preferredStyleVar);
             if (preferredStyle !== null) {
                 changeStyleTo(preferredStyle);
             }
@@ -58,7 +73,7 @@
                 {% for style in styles %}
                     <option
                       value="{{style.name}}"
-                      {% if style.name == 'default' %}
+                      {% if style.name == defaultStyle %}
                           selected="selected"
                       {% endif %}
                     >{{style.name}}</option>


### PR DESCRIPTION
Fixes #60

This is useful because a lot of people seem to prefer a dark theme for terminal output pastes, but a light theme for normal pastes.

This makes monokai the default for terminal output pastes, and keeps "default" as the default for regular pastes. The theme preference is now separated out: you can have a theme configured for regular pastes, and a separate theme configured for terminal output pastes.