### PR TITLE
Implement clientside upload history

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ $(VENV): setup.py cli/setup.py requirements.txt requirements-dev.txt
 	$@/bin/pip install -r requirements.txt -r requirements-dev.txt -e cli -e .
 
 fluffy/static/app.css: $(VENV) $(wildcard fluffy/static/scss/*.scss)
-	$(BIN)/sassc fluffy/static/scss/app.scss $@
+	$(BIN)/pysassc fluffy/static/scss/app.scss $@
 
 fluffy/static/pygments.css: $(VENV) fluffy/component/styles.py
 	$(BIN)/python -m fluffy.component.styles > $@

--- a/fluffy/app.py
+++ b/fluffy/app.py
@@ -1,4 +1,6 @@
+import functools
 import logging
+import os
 import sys
 
 from flask import Flask
@@ -10,6 +12,12 @@ app = Flask(__name__)
 app.config.from_envvar('FLUFFY_SETTINGS')
 app.logger.addHandler(logging.StreamHandler(sys.stderr))
 app.logger.setLevel(logging.DEBUG)
+
+
+@functools.lru_cache
+def _base_javascript():
+    with open(os.path.join(os.path.dirname(__file__), 'static/js/base.js')) as f:
+        return f.read()
 
 
 @app.context_processor
@@ -24,4 +32,5 @@ def defaults():
         'home_url': app.config['HOME_URL'],
         'custom_footer_html': app.config.get('CUSTOM_FOOTER_HTML'),
         'num_lines': lambda text: len(text.splitlines()),
+        'base_javascript': _base_javascript(),
     }

--- a/fluffy/static/js/base.js
+++ b/fluffy/static/js/base.js
@@ -1,0 +1,86 @@
+// https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#feature-detecting_localstorage
+const hasLocalStorage = ((type) => {
+    var storage;
+    try {
+        storage = window[type];
+        var x = '__storage_test__';
+        storage.setItem(x, x);
+        storage.removeItem(x);
+        return true;
+    }
+    catch(e) {
+        return e instanceof DOMException && (
+            // everything except Firefox
+            e.code === 22 ||
+            // Firefox
+            e.code === 1014 ||
+            // test name field too, because code might not be present
+            // everything except Firefox
+            e.name === 'QuotaExceededError' ||
+            // Firefox
+            e.name === 'NS_ERROR_DOM_QUOTA_REACHED') &&
+            // acknowledge QuotaExceededError only if there's something already stored
+            (storage && storage.length !== 0);
+    }
+})('localStorage');
+
+// Adapted from https://gist.github.com/pomber/6195066a9258d1fb93bb59c206345b38
+const getTimeAgo = (date) => {
+    const MINUTE = 60,
+        HOUR = MINUTE * 60,
+        DAY = HOUR * 24,
+        MONTH = DAY * 30,
+        YEAR = MONTH * 12;
+    const secondsAgo = Math.round((+new Date() - date) / 1000);
+
+    let result;
+    if (secondsAgo < MINUTE) {
+        result = [secondsAgo, 'second'];
+    } else if (secondsAgo < HOUR) {
+        result = [Math.floor(secondsAgo / MINUTE), 'minute'];
+    } else if (secondsAgo < DAY) {
+        result = [Math.floor(secondsAgo / HOUR), 'hour'];
+    } else if (secondsAgo < MONTH) {
+        result = [Math.floor(secondsAgo / DAY), 'day'];
+    } else if (secondsAgo < YEAR) {
+        result = [Math.floor(secondsAgo / MONTH), 'month'];
+    } else {
+        result = [Math.floor(secondsAgo / YEAR), 'year'];
+    }
+
+    return `${result[0]} ${result[1]}${result[0] == 1 ? '' : 's'} ago`;
+};
+
+const uploadHistory = {
+    enabled: () => hasLocalStorage,
+
+    getHistory: () => {
+        if (localStorage.uploadHistory) {
+            return JSON.parse(localStorage.uploadHistory).map(entry => ({
+                url: entry.url,
+                time: new Date(entry.time),
+                fileDetails: entry.fileDetails,
+                pasteDetails: entry.pasteDetails,
+            }));
+        } else {
+            return [];
+        }
+    },
+
+    addItemToHistory: ({ url, time, fileDetails, pasteDetails }) => {
+        const uploadHistory = localStorage.uploadHistory ? JSON.parse(localStorage.uploadHistory) : [];
+        const entry = {
+            url,
+            time: time.getTime(),
+            fileDetails,
+            pasteDetails,
+            version: 1,
+        };
+        uploadHistory.push(entry);
+        localStorage.uploadHistory = JSON.stringify(uploadHistory);
+    },
+
+    clearHistory: () => {
+        delete localStorage.uploadHistory;
+    },
+};

--- a/fluffy/static/js/home.js
+++ b/fluffy/static/js/home.js
@@ -27,7 +27,7 @@ function transitionToText(callback) {
 
 
 function transitionToUpload(callback) {
-    container.animate({'width': '580px'}, TRANSITION_DURATION);
+    container.animate({'width': '680px'}, TRANSITION_DURATION);
     pb.slideUp(TRANSITION_DURATION);
     fh.slideDown(TRANSITION_DURATION, function() {
         transitioningModes = false;

--- a/fluffy/static/js/home.js
+++ b/fluffy/static/js/home.js
@@ -43,7 +43,6 @@ $(document).ready(function() {
     pb = $('.pastebinForm');
     container = $('#container');
 
-
     $('.switch-modes a').click(function() {
         if (transitioningModes) {
             return;
@@ -232,6 +231,19 @@ function upload() {
             // TODO: improve error handling
             if (! data.success) {
                 return alert(data.error);
+            }
+
+            if (uploadHistory.enabled()) {
+                uploadHistory.addItemToHistory({
+                    url: data.redirect,
+                    time: new Date(),
+                    fileDetails: Object.entries(data.uploaded_files).map(([filename, metadata]) => ({
+                        filename,
+                        bytes: metadata.bytes,
+                        rawUrl: metadata.raw,
+                        pasteUrl: metadata.paste,
+                    })),
+                });
             }
 
             window.location.href = data.redirect;

--- a/fluffy/static/scss/app.scss
+++ b/fluffy/static/scss/app.scss
@@ -21,8 +21,12 @@ p.error {
     color: #B20000;
 }
 
+.clearfix {
+    clear: both;
+}
+
 #container {
-    width: 580px;
+    width: 680px;
 
     margin: 100px auto;
     margin-bottom: 35px;

--- a/fluffy/static/scss/app.scss
+++ b/fluffy/static/scss/app.scss
@@ -25,6 +25,10 @@ p.error {
     clear: both;
 }
 
+.hidden {
+    display: none;
+}
+
 #container {
     width: 680px;
 

--- a/fluffy/static/scss/home.scss
+++ b/fluffy/static/scss/home.scss
@@ -226,4 +226,71 @@
             cursor: pointer;
         }
     }
+
+    .recent-uploads {
+        padding: 15px;
+        background-color: #e0feff;
+        border-radius: 3px;
+        margin-top: 20px;
+
+        h3 {
+            text-align: center;
+            font-size: 16px;
+            font-weight: bold;
+            margin-bottom: 15px;
+        }
+
+        .recent-uploads-grid {
+            display: grid;
+            grid-template-columns: 5fr 5fr 5fr 50px;
+            column-gap: 10px;
+
+            a {
+                display: block;
+                background-color: #f8ffff;
+                border-radius: 5px;
+                padding: 10px;
+                color: black;
+                text-decoration: none;
+
+                &:hover {
+                    background-color: #fff7e6;
+                }
+
+                &.recent-uploads-item {
+                    overflow: hidden;
+
+                    img {
+                        float: left;
+                        margin-right: 5px;
+                    }
+
+                    .recent-uploads-text {
+                        font-size: 12px;
+                        color: #9f9f9f;
+                        line-height: 1.2em;
+
+                        strong {
+                            color: black;
+                        }
+
+                        .nowrap {
+                            overflow: hidden;
+                            text-overflow: ellipsis;
+                            white-space: nowrap;
+                        }
+                    }
+                }
+
+                &.recent-uploads-more {
+                    text-align: center;
+                    font-size: 12px;
+                    display: flex;
+                    justify-content: center;
+                    align-content: center;
+                    flex-direction: column;
+                }
+            }
+        }
+    }
 }

--- a/fluffy/static/scss/home.scss
+++ b/fluffy/static/scss/home.scss
@@ -227,11 +227,11 @@
         }
     }
 
-    .recent-uploads {
+    #recent-uploads {
         padding: 15px;
         background-color: #e0feff;
         border-radius: 3px;
-        margin-top: 20px;
+        margin-top: 10px;
 
         h3 {
             text-align: center;
@@ -240,9 +240,9 @@
             margin-bottom: 15px;
         }
 
-        .recent-uploads-grid {
+        #recent-uploads-grid {
             display: grid;
-            grid-template-columns: 5fr 5fr 5fr 50px;
+            grid-template-columns: 1fr 1fr 1fr; // TODO for more button: 50px
             column-gap: 10px;
 
             a {

--- a/fluffy/templates/home.html
+++ b/fluffy/templates/home.html
@@ -91,9 +91,6 @@
 {% endblock %}
 
 {% block inline_js %}
-    {# TODO: inline this somehow to avoid blocking rendering #}
-    <script src="{{asset_url('js/base.js')}}"></script>
-
     <script>
         // determine whether to use basic or advanced upload form
         if (typeof FileReader != "undefined" &&

--- a/fluffy/templates/home.html
+++ b/fluffy/templates/home.html
@@ -66,29 +66,34 @@
             <input class="pasteButton" id="paste" type="submit" value="Paste" />
         </form>
 
-        <div class="recent-uploads">
+        <div id="recent-uploads" class="hidden">
             <h3>your recent uploads</h3>
-            <div class="recent-uploads-grid">
-                {% for _ in range(3) %}
-                    <a href="#" class="recent-uploads-item">
-                        <img src="{{asset_url('img/mime/small/pdf.png')}}" alt="" />
+            <div id="recent-uploads-grid">
+                <template id="recent-uploads-item-tmpl">
+                    <a class="recent-uploads-item">
+                        <img class="recent-uploads-image" />
                         <div class="recent-uploads-text">
-                            <div class="nowrap"><strong>37 lines of Python reall ahlfd asdf asdf asdfa sdfads f</strong></div>
-                            <div class="nowrap">3 days ago</div>
+                            <div class="nowrap"><strong class="recent-uploads-text-title"></strong></div>
+                            <div class="nowrap recent-uploads-text-subtitle"></div>
                         </div>
                         <div class="clearfix"></div>
                     </a>
-                {% endfor %}
-                <a href="#" class="recent-uploads-more">
-                    More<br />
-                    &rarr;
-                </a>
+                </template>
+                {# TODO(ckuehl|2021-10-19): implement this!
+                    <a href="#" class="recent-uploads-more">
+                        More<br />
+                        &rarr;
+                    </a>
+                #}
             </div>
         </div>
     </div>
 {% endblock %}
 
 {% block inline_js %}
+    {# TODO: inline this somehow to avoid blocking rendering #}
+    <script src="{{asset_url('js/base.js')}}"></script>
+
     <script>
         // determine whether to use basic or advanced upload form
         if (typeof FileReader != "undefined" &&
@@ -106,6 +111,67 @@
         };
 
         var maxUploadSize = {{max_upload_size | tojson | safe}};
+    </script>
+
+    <script>
+        (() => {
+            const template = document.getElementById('recent-uploads-item-tmpl').content.firstElementChild;
+            const grid = document.getElementById('recent-uploads-grid');
+
+            const addEntry = (url, image, title, subtitle) => {
+                const entry = template.cloneNode(true);
+                entry.setAttribute('href', url);
+                entry.querySelector('.recent-uploads-image').setAttribute('src', image);
+                entry.querySelector('.recent-uploads-text-title').innerText = title;
+                entry.querySelector('.recent-uploads-text-subtitle').innerText = subtitle;
+                grid.prepend(entry);
+            };
+
+            const titlesForEntry = (entry) => {
+                let title;
+
+                if (entry.pasteDetails) {
+                    title = 'TODO: implement this';
+                } else {
+                    const count = entry.fileDetails.length;
+                    title = `${count} file${count == 1 ? '' : 's'}`;
+                }
+
+                return {
+                    title,
+                    subtitle: getTimeAgo(entry.time),
+                }
+            };
+
+            const iconForEntry = (entry) => {
+                if (entry.pasteDetails) {
+                    return icons['txt'];
+                } else {
+                    // Use the icon from the largest file uploaded that has a known extension.
+                    const candidateIcons = entry.fileDetails
+                        .map(({ filename, bytes }) => [icons[filename.split('.').pop()], bytes])
+                        .filter(([filename, _]) => filename);
+                    if (candidateIcons.length == 0) {
+                        return icons['unknown'];
+                    } else {
+                        // Is there a graceful way to do max() with a key function in JS?
+                        const max = Math.max(...candidateIcons.map(([_, bytes]) => bytes));
+                        return candidateIcons.filter(([_, bytes]) => bytes == max)[0][0];
+                    }
+                }
+            };
+
+            if (uploadHistory.enabled()) {
+                const entries = uploadHistory.getHistory().slice(-3);
+                if (entries.length > 0) {
+                    entries.forEach(entry => {
+                        const { title, subtitle } = titlesForEntry(entry);
+                        addEntry(entry.url, iconForEntry(entry), title, subtitle);
+                    });
+                    document.getElementById('recent-uploads').classList.remove('hidden');
+                }
+            }
+        })();
     </script>
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>

--- a/fluffy/templates/home.html
+++ b/fluffy/templates/home.html
@@ -65,6 +65,26 @@
             </p>
             <input class="pasteButton" id="paste" type="submit" value="Paste" />
         </form>
+
+        <div class="recent-uploads">
+            <h3>your recent uploads</h3>
+            <div class="recent-uploads-grid">
+                {% for _ in range(3) %}
+                    <a href="#" class="recent-uploads-item">
+                        <img src="{{asset_url('img/mime/small/pdf.png')}}" alt="" />
+                        <div class="recent-uploads-text">
+                            <div class="nowrap"><strong>37 lines of Python reall ahlfd asdf asdf asdfa sdfads f</strong></div>
+                            <div class="nowrap">3 days ago</div>
+                        </div>
+                        <div class="clearfix"></div>
+                    </a>
+                {% endfor %}
+                <a href="#" class="recent-uploads-more">
+                    More<br />
+                    &rarr;
+                </a>
+            </div>
+        </div>
     </div>
 {% endblock %}
 

--- a/fluffy/templates/layouts/base.html
+++ b/fluffy/templates/layouts/base.html
@@ -10,6 +10,11 @@
         <link rel="stylesheet" href="{{asset_url('app.css')}}" />
         <link rel="icon" href="{{asset_url('img/favicon.ico')}}" />
 
+        {# This is fairly minimal inlined JS that the rest of the page might rely on early (before rendering has completed). #}
+        <script>
+            {{base_javascript|safe}}
+        </script>
+
         {% block extra_head %}{% endblock %}
     </head>
 

--- a/fluffy/views.py
+++ b/fluffy/views.py
@@ -120,6 +120,7 @@ def upload():
             'redirect': details_obj.url,
             'uploaded_files': {
                 uf.human_name: {
+                    'bytes': uf.num_bytes,
                     'raw': uf.url,
                     'paste': pb.url if pb is not None else None,
                 }

--- a/tests/integration/upload_test.py
+++ b/tests/integration/upload_test.py
@@ -38,6 +38,7 @@ def test_single_file_upload_json(content, running_server):
         'redirect': mock.ANY,
         'uploaded_files': {
             'ohai.bin': {
+                'bytes': len(content),
                 'paste': mock.ANY,
                 'raw': mock.ANY,
             },
@@ -80,8 +81,8 @@ def test_multiple_files_upload_json(running_server):
         'success': True,
         'redirect': mock.ANY,
         'uploaded_files': {
-            f'ohai{i}.bin': {'paste': mock.ANY, 'raw': mock.ANY}
-            for i in range(len(FILE_CONTENT_TESTCASES))
+            f'ohai{i}.bin': {'bytes': len(content), 'paste': mock.ANY, 'raw': mock.ANY}
+            for i, content in enumerate(FILE_CONTENT_TESTCASES)
         },
     }
 


### PR DESCRIPTION
This adds a new "recent uploads" section to the home page:
![](https://i.fluffy.cc/cssMbsMklgSN156RGGW9kVgDswzpB5Bw.png)

In the near future this will also support pastes and have a separate page listing full history (and allowing to clear the history or particular items if desired).

All data is stored clientside (in `localStorage`).