### PR TITLE
Remove guesslang from minimal requirements

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -2,7 +2,6 @@ boto3
 cached_property
 csscompressor
 flask
-guesslang
 identify
 # https://github.com/chriskuehl/fluffy/issues/126
 mistune<0.999


### PR DESCRIPTION
This was only meant to be an optional requirement.