### PR TITLE
show a checkbox to word wrap text

### DIFF
--- a/fluffy/templates/home.html
+++ b/fluffy/templates/home.html
@@ -39,6 +39,10 @@
                 <textarea id="text" name="text" placeholder="paste text here" required autofocus>{{text}}</textarea>
             </p>
             <p>
+                <input type="checkbox" id="word_wrap" name="word_wrap" value="word_wrap">
+                <label for="word_wrap">Word Wrap</label>
+            </p>
+            <p>
                 <select name="language">
                     <option selected="selected" value="">Guess the language for me</option>
                     <option value="text">Plain text</option>

--- a/fluffy/templates/layouts/text.html
+++ b/fluffy/templates/layouts/text.html
@@ -14,6 +14,9 @@
             <a class="button" href="{{raw_url}}">
                 Raw Text
             </a>
+            <a class="button" id="do_word_wrap" href="#">
+                Word Wrap
+            </a>
 
             <form method="POST" action="{{home_url}}">
                 <input type="hidden" name="text" value="{{text}}" />

--- a/fluffy/views.py
+++ b/fluffy/views.py
@@ -1,5 +1,6 @@
 import contextlib
 import json
+import textwrap
 import time
 
 from flask import jsonify
@@ -152,6 +153,10 @@ def paste():
                 human_size(num_bytes),
             ), 413
         objects.append(uf)
+
+        if request.form.get('word_wrap'):
+            wrapper = textwrap.TextWrapper(width=50)
+            text = wrapper.fill(text=text)
 
         # HTML view (Markdown or paste)
         lang = request.form['language']


### PR DESCRIPTION
## Demo
https://user-images.githubusercontent.com/10975326/167837461-0da5477b-5383-493a-9b43-6f553d6dfc3c.mov

## Description + Issues
- The application generates rendered html pages as result. In order to do a word wrap after pasting and submitting the text would cause performance issues in runtime as well as storage.
- It would require to re run the entire /paste endpoint - generating duplicate htmls + re-rendering the same.
- Hence
<img width="1704" alt="Screenshot 2022-05-11 at 13 24 32" src="https://user-images.githubusercontent.com/10975326/167838399-e2fb98e5-769e-47ea-b4a4-f647fb5c916e.png">
 this checkbox before submitting the item.


Please let me know if you have an idea how to do it in the editor itself. for example here.
<img width="1704" alt="Screenshot 2022-05-11 at 13 23 11" src="https://user-images.githubusercontent.com/10975326/167838183-b969abb6-f54e-4aa9-aca1-73c46a1509d7.png">

