### PR TITLE
Add a max-width for images in rendered Markdown

### DIFF
--- a/fluffy/static/scss/markdown.scss
+++ b/fluffy/static/scss/markdown.scss
@@ -97,4 +97,8 @@ $source-code-font: 'Source Code Pro', monospace;
         font-weight: bold;
         background-color: #f1f1f1;
     }
+
+    img {
+        max-width: 100%;
+    }
 }


### PR DESCRIPTION
## Before

![](https://i.fluffy.cc/87kg59WnJv5T2sht9Gz3CSsqz3dG6NF9.png)

## After

![](https://i.fluffy.cc/BgFsQ6BCJcS4b7xnGqWpmrLDt1xRBVB7.png)