### PR TITLE
Group simultaneous changes on each diff side at same line

### DIFF
--- a/fluffy/component/highlighting.py
+++ b/fluffy/component/highlighting.py
@@ -84,18 +84,30 @@ class DiffHighlighter(namedtuple('DiffHighlighter', ('lexer',))):
         """Transform the unified diff into a side-by-side diff."""
         diff1 = []
         diff2 = []
+
+        def _fill_empty_lines():
+            """Fill either side of the diff with empty lines so they have the same length."""
+            diff1.extend([''] * max(0, (len(diff2) - len(diff1))))
+            diff2.extend([''] * max(0, (len(diff1) - len(diff2))))
+
         for line in text.splitlines():
             if line in ('--- ', '+++ '):
                 pass
             elif line.startswith('-'):
                 diff1.append(line)
-                diff2.append('')
             elif line.startswith('+'):
-                diff1.append('')
                 diff2.append(line)
             else:
+                # Fill empty lines so that both sides are "caught up" after any
+                # additions/deletions and we can print the lines both sides
+                # contain side-by-side.
+                _fill_empty_lines()
+
                 diff1.append(line)
                 diff2.append(line)
+
+        _fill_empty_lines()
+        assert len(diff1) == len(diff2), (len(diff1), len(diff2))
         return ['\n'.join(diff1), '\n'.join(diff2)]
 
     def highlight(self, text):

--- a/tests/unit/component/highlighting_test.py
+++ b/tests/unit/component/highlighting_test.py
@@ -147,3 +147,43 @@ def test_get_highlighter_diff(text, language, expected):
     h = get_highlighter(text, language, None)
     assert isinstance(h, DiffHighlighter)
     assert type(h.lexer) is type(expected)
+
+
+def test_diff_highlighter_prepare_text():
+    highlighter = DiffHighlighter(pygments.lexers.get_lexer_by_name('text'))
+    text1, text2 = highlighter.prepare_text('''\
+ common line 1
++added line 1
+ common line 2
++added line 2
+-deleted line 1
+-deleted line 2
+ common line 3
+-deleted line 3
++added line 3
+ common line 4
++added line 4
+-deleted line 4
+-deleted line 5''')
+    assert text1 == '''\
+ common line 1
+
+ common line 2
+-deleted line 1
+-deleted line 2
+ common line 3
+-deleted line 3
+ common line 4
+-deleted line 4
+-deleted line 5'''
+    assert text2 == '''\
+ common line 1
++added line 1
+ common line 2
++added line 2
+
+ common line 3
++added line 3
+ common line 4
++added line 4
+'''


### PR DESCRIPTION
When there is a change on both halves of the diff at the same line, it now presents both sides of the diff at the same start position rather than the left-side changes at the start position and the right-side changes pushed down below all of the left-side change lines. This makes the diffs a bit more compact and also generally shows changed lines side-by-side now.

Easier to explain with an example:

### Before:

![Screenshot_2023-04-29_20-00-06](https://user-images.githubusercontent.com/665269/235330582-ede1e56a-50a0-4518-8287-9e4ee26ac8c3.png)


### After:

![Screenshot_2023-04-29_19-59-45](https://user-images.githubusercontent.com/665269/235330579-20e8ce9c-dda5-40a9-b469-733c2a7b5c73.png)

This also matches how GitHub renders the same diff:

![Screenshot_2023-04-29_20-01-53](https://user-images.githubusercontent.com/665269/235330614-8f9c710d-448c-481d-8cfd-1c11842c3048.png)

cc @fragosoluana  @Mantas-Skackauskas