### PR TITLE
Add an option for unified diffs

### DIFF
--- a/fluffy/component/highlighting.py
+++ b/fluffy/component/highlighting.py
@@ -56,6 +56,8 @@ _pygments_formatter = FluffyFormatter(
 
 class PygmentsHighlighter(namedtuple('PygmentsHighlighter', ('lexer',))):
 
+    is_diff = False
+
     @property
     def name(self):
         return self.lexer.name
@@ -75,6 +77,7 @@ class PygmentsHighlighter(namedtuple('PygmentsHighlighter', ('lexer',))):
 class DiffHighlighter(namedtuple('DiffHighlighter', ('lexer',))):
 
     is_terminal_output = False
+    is_diff = True
 
     @property
     def name(self):
@@ -108,7 +111,7 @@ class DiffHighlighter(namedtuple('DiffHighlighter', ('lexer',))):
 
         _fill_empty_lines()
         assert len(diff1) == len(diff2), (len(diff1), len(diff2))
-        return ['\n'.join(diff1), '\n'.join(diff2)]
+        return ['\n'.join(diff1), '\n'.join(diff2), text]
 
     def highlight(self, text):
         html = pq(_highlight(text, self.lexer))

--- a/fluffy/static/scss/paste.scss
+++ b/fluffy/static/scss/paste.scss
@@ -67,4 +67,25 @@
             }
         }
     }
+
+    &.diff-side-by-side {
+        #paste {
+            .text-container:nth-child(3) {
+                display: none;
+            }
+        }
+    }
+
+    &.diff-unified {
+        #paste {
+            .text-container:nth-child(1), .text-container:nth-child(2) {
+                display: none;
+            }
+
+            .text-container:nth-child(3) {
+                /* This is super janky... */
+                border-left: none;
+            }
+        }
+    }
 }

--- a/fluffy/static/scss/text.scss
+++ b/fluffy/static/scss/text.scss
@@ -21,15 +21,53 @@
 
         .button {
             float: right;
-            font-size: 14px;
-            background-color: #f3f3f3 !important;
             margin-left: 8px;
-            padding: 8px;
-            text-decoration: none;
-            color: #333;
 
             &:hover {
                 opacity: 0.8;
+            }
+        }
+
+        .button, .pill-buttons .option {
+            font-size: 14px;
+            background-color: #f3f3f3 !important;
+            text-decoration: none;
+            color: #333;
+            padding: 8px;
+        }
+
+        .pill-buttons {
+            display: flex;
+            padding-left: 12px;
+
+            .option {
+                padding: 8px 10px;
+                border-right: solid 1px #bbb;
+
+                &.selected {
+                    background-color: #b8b8b8 !important;
+                    color: white;
+                    text-shadow: 1px 1px #9d9d9db8;
+                }
+
+                &.not-selected {
+                    cursor: pointer;
+
+                    &:hover {
+                        opacity: 0.8;
+                    }
+                }
+
+                &:first-child {
+                    border-top-left-radius: 5px;
+                    border-bottom-left-radius: 5px;
+                }
+
+                &:last-child {
+                    border-top-right-radius: 5px;
+                    border-bottom-right-radius: 5px;
+                    border-right: none;
+                }
             }
         }
     }

--- a/fluffy/templates/paste.html
+++ b/fluffy/templates/paste.html
@@ -1,6 +1,10 @@
 {% set page_name = 'paste' %}
 {% extends 'layouts/text.html' %}
 
+{% if highlighter.is_diff %}
+    {% set extra_html_classes = "diff-side-by-side" %}
+{% endif %}
+
 {#
     Terminal output gets its own preferred theme setting, since many people
     seem to prefer a dark background for terminal output, but a light
@@ -69,6 +73,52 @@
             document.getElementById('style').value = preferredStyle;
         }
     </script>
+
+    {% if highlighter.is_diff %}
+        <div class="pill-buttons" id="diff-setting">
+            <div class="option selected" data-value="side-by-side">Side-by-Side</div>
+            <div class="option not-selected" data-value="unified">Unified</div>
+        </div>
+
+        {#
+            This is an inline script so that it can apply the right CSS before
+            rendering the diff and avoid flashing the wrong diff style on load.
+        #}
+        <script>
+            const PREFERRED_DIFF_SETTING = 'preferredDiffSetting';
+
+            const diffSetting = document.getElementById('diff-setting');
+            const updateDiffSetting = (setting) => {
+                localStorage.setItem(PREFERRED_DIFF_SETTING, setting);
+                for (const child of diffSetting.children) {
+                    if (child.getAttribute('data-value') === setting) {
+                        child.classList.add('selected');
+                        child.classList.remove('not-selected');
+                    } else {
+                        child.classList.remove('selected');
+                        child.classList.add('not-selected');
+                    }
+                }
+
+                const html = document.getElementsByTagName('html')[0];
+                if (setting === 'side-by-side') {
+                    html.classList.add('diff-side-by-side');
+                    html.classList.remove('diff-unified');
+                } else {
+                    html.classList.remove('diff-side-by-side');
+                    html.classList.add('diff-unified');
+                }
+            };
+
+            if (hasLocalStorage && localStorage.getItem(PREFERRED_DIFF_SETTING) !== null) {
+                updateDiffSetting(localStorage.getItem(PREFERRED_DIFF_SETTING));
+            }
+
+            for (const child of diffSetting.children) {
+                child.onclick = () => updateDiffSetting(child.getAttribute('data-value'))
+            }
+        </script>
+    {% endif %}
 {% endblock %}
 
 {% block inline_js %}

--- a/tests/unit/component/highlighting_test.py
+++ b/tests/unit/component/highlighting_test.py
@@ -151,7 +151,7 @@ def test_get_highlighter_diff(text, language, expected):
 
 def test_diff_highlighter_prepare_text():
     highlighter = DiffHighlighter(pygments.lexers.get_lexer_by_name('text'))
-    text1, text2 = highlighter.prepare_text('''\
+    orig_text = '''\
  common line 1
 +added line 1
  common line 2
@@ -164,7 +164,9 @@ def test_diff_highlighter_prepare_text():
  common line 4
 +added line 4
 -deleted line 4
--deleted line 5''')
+-deleted line 5'''
+
+    text1, text2, text3 = highlighter.prepare_text(orig_text)
     assert text1 == '''\
  common line 1
 
@@ -187,3 +189,4 @@ def test_diff_highlighter_prepare_text():
  common line 4
 +added line 4
 '''
+    assert text3 == orig_text


### PR DESCRIPTION
This adds an option to toggle between side-by-side and unified diffs:
![Screenshot_2023-05-10_01-34-33](https://github.com/chriskuehl/fluffy/assets/665269/e46a8985-badd-4969-af97-351adae0a605)

The selection persists in localStorage so will apply to future diff loads as well.