### PR TITLE
Fix line number mismatch when switching between side-by-side and unified diffs

### DIFF
--- a/fluffy/templates/paste.html
+++ b/fluffy/templates/paste.html
@@ -44,10 +44,10 @@
                 {% for i in range(1, num_lines(text.text) + 1) %}
                     {% if text.line_number_mapping %}
                         {% set line_numbers = text.line_number_mapping[i] %}
-                        <a class="{% for line_number in line_numbers %}LL{{line_number}} {% endfor %}">{{line_numbers[0]}}</a>
                     {% else %}
-                        <a class="LL{{i}}">{{i}}</a>
+                        {% set line_numbers = [i] %}
                     {% endif %}
+                    <a class="LL{{line_numbers|join(' LL')}}">{{i}}</a>
                 {% endfor %}
             </div>
             <div class="text" contenteditable="true" spellcheck="false">

--- a/fluffy/templates/paste.html
+++ b/fluffy/templates/paste.html
@@ -25,7 +25,7 @@
 
 {% block info %}
     {% if texts|length == 1 %}
-        {{num_lines(texts[0])}} {{'line'|pluralize(num_lines(texts[0]))}} of
+        {{num_lines(texts[0].text)}} {{'line'|pluralize(num_lines(texts[0].text))}} of
     {% endif %}
     {{highlighter.name}}
 {% endblock %}
@@ -41,12 +41,17 @@
     {% for text in texts %}
         <div class="text-container">
             <div class="line-numbers">
-                {% for i in range(1, num_lines(text) + 1) %}
-                    <a class="LL{{i}}">{{i}}</a>
+                {% for i in range(1, num_lines(text.text) + 1) %}
+                    {% if text.line_number_mapping %}
+                        {% set line_numbers = text.line_number_mapping[i] %}
+                        <a class="{% for line_number in line_numbers %}LL{{line_number}} {% endfor %}">{{line_numbers[0]}}</a>
+                    {% else %}
+                        <a class="LL{{i}}">{{i}}</a>
+                    {% endif %}
                 {% endfor %}
             </div>
             <div class="text" contenteditable="true" spellcheck="false">
-                {{highlighter.highlight(text)|safe}}
+                {{highlighter.highlight(text.text, text.line_number_mapping)|safe}}
             </div>
         </div>
     {% endfor %}

--- a/tests/unit/component/highlighting_test.py
+++ b/tests/unit/component/highlighting_test.py
@@ -5,6 +5,7 @@ from fluffy.component.highlighting import DiffHighlighter
 from fluffy.component.highlighting import get_highlighter
 from fluffy.component.highlighting import guess_lexer
 from fluffy.component.highlighting import looks_like_diff
+from fluffy.component.highlighting import PasteText
 from fluffy.component.highlighting import PygmentsHighlighter
 from fluffy.component.highlighting import strip_diff_things
 from fluffy.component.highlighting import UI_LANGUAGES_MAP
@@ -167,7 +168,8 @@ def test_diff_highlighter_prepare_text():
 -deleted line 5'''
 
     text1, text2, text3 = highlighter.prepare_text(orig_text)
-    assert text1 == '''\
+    assert text1 == PasteText(
+        '''\
  common line 1
 
  common line 2
@@ -177,8 +179,22 @@ def test_diff_highlighter_prepare_text():
 -deleted line 3
  common line 4
 -deleted line 4
--deleted line 5'''
-    assert text2 == '''\
+-deleted line 5''',
+        {
+            1: [1],
+            2: [2],
+            3: [3],
+            4: [4, 5],
+            5: [6],
+            6: [7],
+            7: [8, 9],
+            8: [10],
+            9: [11, 12],
+            10: [13],
+        },
+    )
+    assert text2 == PasteText(
+        '''\
  common line 1
 +added line 1
  common line 2
@@ -188,5 +204,18 @@ def test_diff_highlighter_prepare_text():
 +added line 3
  common line 4
 +added line 4
-'''
-    assert text3 == orig_text
+''',
+        {
+            1: [1],
+            2: [2],
+            3: [3],
+            4: [4, 5],
+            5: [6],
+            6: [7],
+            7: [8, 9],
+            8: [10],
+            9: [11, 12],
+            10: [13],
+        },
+    )
+    assert text3 == PasteText(orig_text)


### PR DESCRIPTION
Fixes #163

The idea is to introduce an optional line number mapping when rendering text, such that one line of text in one rendered text view can map to (at least one, potentially multiple) different line numbers in the source text.

For example, if you have a unified diff like

```diff
--- a/testing/__init__.py  # 1
+++ b/testing/__init__.py  # 2
 existing line             # 3
+new line                  # 4
```

...then the left-hand diff would look like:

```diff
--- a/testing/__init__.py  # 1 => [1, 2]
 existing line             # 2 => [3]
                           # 3 => [4]  (empty line)
```

...and the right-hand diff would look like:

```diff
+++ b/testing/__init__.py  # 1 => [1, 2]
 existing line             # 2 => [3]
+new line                  # 3 => [4]
```

The side-by-side diffs have fewer rendered lines since +/- lines are rendered only on one side of the diff each at the same line position.

This PR introduces this mapping and updates all of the line selection logic so that lines are always selected against the mapped lines (which correspond the unified diff in this case, since it is the "raw" text for the paste and also always at least as long as the side-by-diff). So if you select "1" on the above side-by-side diffs, it will actually select both lines 1 and 2 behind the scenes and update the location hash and unified diff view that way. From the user perspective though, it behaves exactly as normal except that the lines in the location hash match the unified diff rather than the side-by-side diff.

This allows you to select lines on either the side-by-side or unified diff view and switch between the two while keeping selected lines at the right line. This is especially useful when sharing links with selected lines as otherwise if you send a link to someone with a different diff option, it will be highlighting the wrong lines.

Need a little more testing before merging.