### PR TITLE
Prevent empty lines at the end of text from being lost

### DIFF
--- a/fluffy/app.py
+++ b/fluffy/app.py
@@ -48,6 +48,6 @@ def defaults():
         'fluffy_version': version,
         'home_url': app.config['HOME_URL'],
         'custom_footer_html': app.config.get('CUSTOM_FOOTER_HTML'),
-        'num_lines': lambda text: len(text.splitlines()),
+        'num_lines': lambda text: len(text.split('\n')),
         'inline_js': _inline_js,
     }

--- a/fluffy/component/highlighting.py
+++ b/fluffy/component/highlighting.py
@@ -249,7 +249,16 @@ def guess_lexer(text, language, filename, opts=None):
 
 def _highlight(text, lexer):
     text = pygments.highlight(
-        text,
+        # Pygments works most consistently when the text is a series of lines
+        # ending with newlines. The rest of fluffy is not treating lines that
+        # way (instead, \n means start a new line which should actually be
+        # displayed) so we always append a newline here.
+        #
+        # This has no effect if the final line of the text has characters on
+        # it, but if the last line is empty (i.e. final character is already a
+        # newline in `text`), Pygments will chop off the last line unless we do
+        # this.
+        text + '\n' if len(text) > 0 else text,
         lexer,
         _pygments_formatter,
     )


### PR DESCRIPTION
This is a long-standing issue but was especially noticeable on diffs since frequently one side of the diff will end in multiple empty lines.

### Before
![Screenshot_2023-05-13_01-53-51](https://github.com/chriskuehl/fluffy/assets/665269/7e131e7c-feae-45d2-ad6f-55920930e811)

### After
![Screenshot_2023-05-13_01-53-19](https://github.com/chriskuehl/fluffy/assets/665269/d9a03994-d569-4158-88dc-ab14779340a7)