### PR TITLE
Fix line colors not extending full width when overflow is present

### DIFF
--- a/fluffy/static/scss/paste.scss
+++ b/fluffy/static/scss/paste.scss
@@ -51,9 +51,13 @@
 
         .text {
             padding: $paste-padding-top 0;
+            overflow-x: auto;
 
-            pre {
-                overflow-x: auto;
+            .highlight {
+                // Allow width to expand to match content so block element
+                // children (e.g. lines) extend the full width.
+                display: inline-block;
+                min-width: 100%;
             }
 
             .highlight > pre {


### PR DESCRIPTION
Fixes #35

![Screenshot_2023-05-13_02-13-22](https://github.com/chriskuehl/fluffy/assets/665269/4e109ab4-ce61-47a1-8701-9127304cb422)
