### PR TITLE
Improve language autodetection and add markdown rendering

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,28 @@
+## Development setup
+
+Prerequisites: Python 3.14+, Go 1.23+, [uv](https://docs.astral.sh/uv/).
+
+```bash
+make minimal          # creates venv, builds fpb/fput, compiles assets, symlinks settings.py
+make dev              # starts the Flask dev server on port 5000
+```
+
+You also need a static file server to serve uploaded content locally:
+
+```bash
+mkdir -p tmp/object tmp/html
+python -m http.server 4999 --directory tmp
+```
+
+## Running tests
+
+`make minimal` must complete before tests will pass (assets and Go binaries are required).
+
+```bash
+make test             # Go tests + Python tests with coverage
+```
+
+
 ## Release process (server)
 
 1. Bump version in `fluffy/__init__.py`

--- a/fluffy/component/highlighting.py
+++ b/fluffy/component/highlighting.py
@@ -53,6 +53,38 @@ _pygments_formatter = FluffyFormatter(
     style=DEFAULT_STYLE,
 )
 
+_CONTENT_HEURISTICS = [
+    (
+        [re.compile(
+            r'\b(?:SELECT\s+.+?\s+FROM|INSERT\s+INTO|CREATE\s+TABLE|UPDATE\s+.+?\s+SET|DELETE\s+FROM)\b',
+            re.IGNORECASE | re.DOTALL,
+        )],
+        'sql',
+    ),
+    (
+        [re.compile(r'^\s*[\[{].*?"[^"]+"\s*:', re.DOTALL)],
+        'json',
+    ),
+    (
+        [re.compile(
+            r'^\s*(?:<\?xml\b|<!DOCTYPE\b|<html[\s>]|<[a-z][a-z0-9]*[\s>])',
+            re.IGNORECASE,
+        )],
+        'html',
+    ),
+    (
+        [
+            re.compile(r'(?m)^\s*\[[^\]\n]+\]\s*$'),
+            re.compile(r'(?m)^\s*[A-Za-z0-9_.-]+\s*=\s*.+$'),
+        ],
+        'ini',
+    ),
+    (
+        [re.compile(r'(?m)^---\s*$')],
+        'yaml',
+    ),
+]
+
 
 @dataclasses.dataclass(frozen=True)
 class PasteText:
@@ -228,6 +260,37 @@ def get_highlighter(text, language, filename):
     return PygmentsHighlighter(lexer)
 
 
+_HEURISTIC_HEAD_BYTES = 8192
+
+_MARKDOWN_SIGNALS = [
+    re.compile(r'(?m)^#{1,6}\s+\S'),
+    re.compile(r'(?m)^```'),
+    re.compile(r'\[.+?\]\(.+?\)'),
+    re.compile(r'\*\*.+?\*\*'),
+]
+_MARKDOWN_FRONTMATTER = re.compile(r'^---\s*\n')
+_MARKDOWN_SIGNAL_THRESHOLD = 2
+
+
+def looks_like_markdown(text):
+    head = text[:_HEURISTIC_HEAD_BYTES]
+    score = 0
+    if _MARKDOWN_FRONTMATTER.match(head):
+        score += 2
+    for pattern in _MARKDOWN_SIGNALS:
+        if pattern.search(head):
+            score += 1
+    return score >= _MARKDOWN_SIGNAL_THRESHOLD
+
+
+def _guess_from_text_heuristics(text, lexer_opts):
+    head = text[:_HEURISTIC_HEAD_BYTES]
+    for regexes, lexer_name in _CONTENT_HEURISTICS:
+        if all(r.search(head) for r in regexes):
+            return pygments.lexers.get_lexer_by_name(lexer_name, **lexer_opts)
+    return None
+
+
 def guess_lexer(text, language, filename, opts=None):
     lexer_opts = {'stripnl': False}
     if opts:
@@ -249,6 +312,11 @@ def guess_lexer(text, language, filename, opts=None):
     # Finally, try to guess by looking at the file content.
     try:
         lexer = pygments.lexers.guess_lexer(text, **lexer_opts)
+
+        if isinstance(lexer, pygments.lexers.TextLexer):
+            heuristic_lexer = _guess_from_text_heuristics(text, lexer_opts)
+            if heuristic_lexer is not None:
+                return heuristic_lexer
 
         # Newer versions of Pygments will virtually always fall back to
         # TextLexer due to its 0.01 priority (which is what it returns on

--- a/fluffy/component/highlighting.py
+++ b/fluffy/component/highlighting.py
@@ -55,10 +55,12 @@ _pygments_formatter = FluffyFormatter(
 
 _CONTENT_HEURISTICS = [
     (
-        [re.compile(
-            r'\b(?:SELECT\s+.+?\s+FROM|INSERT\s+INTO|CREATE\s+TABLE|UPDATE\s+.+?\s+SET|DELETE\s+FROM)\b',
-            re.IGNORECASE | re.DOTALL,
-        )],
+        [
+            re.compile(
+                r'\b(?:SELECT\s+.+?\s+FROM|INSERT\s+INTO|CREATE\s+TABLE|UPDATE\s+.+?\s+SET|DELETE\s+FROM)\b',
+                re.IGNORECASE | re.DOTALL,
+            ),
+        ],
         'sql',
     ),
     (
@@ -66,10 +68,12 @@ _CONTENT_HEURISTICS = [
         'json',
     ),
     (
-        [re.compile(
-            r'^\s*(?:<\?xml\b|<!DOCTYPE\b|<html[\s>]|<[a-z][a-z0-9]*[\s>])',
-            re.IGNORECASE,
-        )],
+        [
+            re.compile(
+                r'^\s*(?:<\?xml\b|<!DOCTYPE\b|<html[\s>]|<[a-z][a-z0-9]*[\s>])',
+                re.IGNORECASE,
+            ),
+        ],
         'html',
     ),
     (

--- a/fluffy/views.py
+++ b/fluffy/views.py
@@ -14,6 +14,7 @@ from fluffy import version as FLUFFY_VERSION
 from fluffy.app import app
 from fluffy.component.backends import get_backend
 from fluffy.component.highlighting import get_highlighter
+from fluffy.component.highlighting import looks_like_markdown
 from fluffy.component.highlighting import UI_LANGUAGES_MAP
 from fluffy.component.styles import STYLES_BY_CATEGORY
 from fluffy.models import ExtensionForbiddenError
@@ -83,20 +84,33 @@ def upload():
                     except UnicodeDecodeError:
                         pass
                     else:
-                        highlighter = get_highlighter(text, None, uf.human_name)
-                        pb = ctx.enter_context(
-                            HtmlToStore.from_html(
-                                render_template(
-                                    'paste.html',
-                                    texts=highlighter.prepare_text(text),
-                                    copy_and_edit_text=text,
-                                    highlighter=highlighter,
-                                    raw_url=app.config['FILE_URL'].format(name=uf.name),
-                                    styles=STYLES_BY_CATEGORY,
+                        if uf.human_name and uf.human_name.endswith('.md'):
+                            pb = ctx.enter_context(
+                                HtmlToStore.from_html(
+                                    render_template(
+                                        'markdown.html',
+                                        text=text,
+                                        copy_and_edit_text=text,
+                                        raw_url=app.config['FILE_URL'].format(name=uf.name),
+                                    ),
+                                    unique_id=uf.unique_id,
                                 ),
-                                unique_id=uf.unique_id,
-                            ),
-                        )
+                            )
+                        else:
+                            highlighter = get_highlighter(text, None, uf.human_name)
+                            pb = ctx.enter_context(
+                                HtmlToStore.from_html(
+                                    render_template(
+                                        'paste.html',
+                                        texts=highlighter.prepare_text(text),
+                                        copy_and_edit_text=text,
+                                        highlighter=highlighter,
+                                        raw_url=app.config['FILE_URL'].format(name=uf.name),
+                                        styles=STYLES_BY_CATEGORY,
+                                    ),
+                                    unique_id=uf.unique_id,
+                                ),
+                            )
                         objects.append(pb)
 
                 uploaded_files.append((uf, pb))
@@ -207,6 +221,8 @@ def paste():
 
         # HTML view (Markdown or paste)
         lang = request.form['language']
+        if lang in ('', 'autodetect') and looks_like_markdown(transformed_text):
+            lang = 'rendered-markdown'
         if lang != 'rendered-markdown':
             highlighter = get_highlighter(transformed_text, lang, None)
             lang_title = highlighter.name

--- a/fluffy/views.py
+++ b/fluffy/views.py
@@ -84,7 +84,7 @@ def upload():
                     except UnicodeDecodeError:
                         pass
                     else:
-                        if uf.human_name and uf.human_name.endswith('.md'):
+                        if uf.human_name and uf.human_name.lower().endswith('.md'):
                             pb = ctx.enter_context(
                                 HtmlToStore.from_html(
                                     render_template(

--- a/tests/unit/component/highlighting_test.py
+++ b/tests/unit/component/highlighting_test.py
@@ -78,6 +78,24 @@ def test_guess_lexer_autodetects_with_invalid_lang(invalid_lang):
     assert guess_lexer(EXAMPLE_C, invalid_lang, None).name == 'C'
 
 
+def test_guess_lexer_heuristic_detects_sql(monkeypatch):
+    monkeypatch.setattr(
+        pygments.lexers,
+        'guess_lexer',
+        lambda *_args, **kwargs: pygments.lexers.TextLexer(**kwargs),
+    )
+    assert guess_lexer('SELECT id FROM users WHERE active = 1;', None, None).name == 'SQL'
+
+
+def test_guess_lexer_heuristic_detects_json(monkeypatch):
+    monkeypatch.setattr(
+        pygments.lexers,
+        'guess_lexer',
+        lambda *_args, **kwargs: pygments.lexers.TextLexer(**kwargs),
+    )
+    assert guess_lexer('{"name": "fluffy", "enabled": true}', None, None).name == 'JSON'
+
+
 def test_guess_lexer_falls_back_to_python():
     assert guess_lexer('what language even is this', None, None).name == 'Python'
 

--- a/tests/unit/component/markdown_test.py
+++ b/tests/unit/component/markdown_test.py
@@ -1,0 +1,70 @@
+import pytest
+
+from fluffy.component.highlighting import looks_like_markdown
+
+
+REAL_MARKDOWN = '''\
+# My Document
+
+This is a paragraph with a [link](https://example.com).
+
+## Section Two
+
+```python
+print("hello")
+```
+'''
+
+FRONTMATTER_ONLY = '''\
+---
+title: My Post
+date: 2024-01-01
+---
+
+Just some text here.
+'''
+
+SINGLE_HEADER = '''\
+# Title
+
+Just a title and some plain text below it.
+'''
+
+PLAIN_TEXT = '''\
+The quick brown fox jumps over the lazy dog.
+Nothing special about this text at all.
+'''
+
+LOG_OUTPUT = '''\
+2024-01-01 12:00:00 INFO Starting server on port 8080
+2024-01-01 12:00:01 WARN * connection timeout after 30s *
+2024-01-01 12:00:02 ERROR ** fatal: out of memory **
+'''
+
+BOLD_AND_HEADER = '''\
+# Configuration Guide
+
+Set **debug** to true and **verbose** to false.
+'''
+
+
+@pytest.mark.parametrize(
+    ('text', 'expected'),
+    (
+        (REAL_MARKDOWN, True),
+        (FRONTMATTER_ONLY, True),
+        (BOLD_AND_HEADER, True),
+        (SINGLE_HEADER, False),
+        (PLAIN_TEXT, False),
+        (LOG_OUTPUT, False),
+        ('', False),
+    ),
+)
+def test_looks_like_markdown(text, expected):
+    assert looks_like_markdown(text) is expected
+
+
+def test_looks_like_markdown_only_checks_head():
+    padding = 'x' * 10000
+    late_markdown = padding + '# Header\n\n[link](url)\n'
+    assert looks_like_markdown(late_markdown) is False


### PR DESCRIPTION
## Problem or Feature
When Pygments can't detect a language, fluffy labels pastes as Python, which is misleading for SQL, JSON, YAML, etc. Separately, markdown has to be explicitly selected for rendering via fput, and it would be great for that to work automatically, given a world where people are sharing .md files quite frequently. 

## Solution
Three changes:
1. Added a regex heuristic table that runs when Pygments returns TextLexer. Covers SQL, JSON, HTML/XML, INI, and YAML. Only checks the first 8KB, adds ~50us overhead. Python is still the fallback.

2. Added markdown auto-detection. The paste endpoint checks for 2+ markdown signals (headers, code fences, links, bold, YAML frontmatter) when language is autodetect. The upload endpoint renders `.md` files specifically as markdown instead of syntax-highlighted paste.

3. Added some instructions to CONTRIBUTING.md.
## Verification
- 138 tests passing (unit + integration + CLI)
- Tested the server locally: SQL autodetect, markdown autodetect, .md upload, .py upload all correct
- Speed: Heuristic path adds ~50us per call on a 270KB input

