### PR TITLE
Run content heuristics when Pygments returns ScdocLexer as well

### DIFF
--- a/fluffy/component/highlighting.py
+++ b/fluffy/component/highlighting.py
@@ -317,19 +317,15 @@ def guess_lexer(text, language, filename, opts=None):
     try:
         lexer = pygments.lexers.guess_lexer(text, **lexer_opts)
 
-        if isinstance(lexer, pygments.lexers.TextLexer):
-            heuristic_lexer = _guess_from_text_heuristics(text, lexer_opts)
-            if heuristic_lexer is not None:
-                return heuristic_lexer
-
         # Newer versions of Pygments will virtually always fall back to
         # TextLexer due to its 0.01 priority (which is what it returns on
         # analyzing any text).
-        if not (
-            isinstance(lexer, pygments.lexers.TextLexer) or
-            # Seems to flag for everything in recent Pygments...
-            isinstance(lexer, pygments.lexers.ScdocLexer)
-        ):
+        # Seems to flag for everything in recent Pygments...
+        if isinstance(lexer, (pygments.lexers.TextLexer, pygments.lexers.ScdocLexer)):
+            heuristic_lexer = _guess_from_text_heuristics(text, lexer_opts)
+            if heuristic_lexer is not None:
+                return heuristic_lexer
+        else:
             return lexer
     except pygments.util.ClassNotFound:
         pass


### PR DESCRIPTION
## Problem or Feature
The content heuristics added in #186 improved how things work, especially for handling markdown. But while releasing internally I discovered that they only run when Pygments returns TextLexer. Pygments sometimes returns ScdocLexer instead (it matches on many inputs in recent versions). ScdocLexer was already being filtered out as unreliable in the code, but the heuristic check wasn't running in that particular logic branch. This meant SQL, for example was sometimes still falling back to Python whenever Pygments happened to pick ScdocLexer over TextLexer.

Found this while testing #186 locally. Pasting a multi-line SQL query (`SELECT ... FROM ... JOIN ... WHERE ...`) showed "7 lines of Python" instead of SQL. Pygments was returning ScdocLexer for that input, which bypassed the heuristic table.

## Solution
Consolidate the two isinstance checks into one: run heuristics for both TextLexer and ScdocLexer, then use a simple else branch for everything else. This replaces the separate "filter out useless lexers" block that followed.

## Verification
- Ran the server locally and saw uploading some multi-line SQL go from '7 lines of Python' to recognizing it as SQL

The other changes in #186 seem to work well internally though!
