### PR TITLE
Add support for installing assets to a file path.

### DIFF
--- a/fluffy/component/assets.py
+++ b/fluffy/component/assets.py
@@ -48,9 +48,42 @@ def asset_url(path):
         )
 
 
+def s3_command(asset_path):
+    return 'aws s3 cp {} s3://{}/{}'.format(
+        asset_path,
+        app.config['STORAGE_BACKEND']['asset_bucket'],
+        app.config['STORAGE_BACKEND']['asset_s3path'].format(
+            name=name_for_asset(
+                os.path.relpath(asset_path, str(STATIC_ROOT)),
+            ),
+        ),
+    )
+
+
+def file_command(asset_path):
+    return 'cp {} {}'.format(
+        asset_path,
+        app.config['STORAGE_BACKEND']['asset_path'].format(
+            name=name_for_asset(
+                os.path.relpath(asset_path, str(STATIC_ROOT)),
+            ),
+        ),
+    )
+
+
 def upload_assets():
-    """Upload assets. Currently supports only S3."""
+    """Upload assets. Currently supports S3 and file backends."""
     commands = []
+
+    builders = {'s3': s3_command, 'file': file_command}
+
+    backend_name = app.config['STORAGE_BACKEND']['name']
+    if backend_name not in builders.keys():
+        print(f"backend type '{backend_name}' not supported.")
+        return
+
+    build_command = builders[backend_name]
+
     for root, dirs, files in os.walk(str(STATIC_ROOT)):
         for fname in files:
             if not fname.endswith('.hash'):
@@ -62,17 +95,7 @@ def upload_assets():
             asset_path = asset_hash_path[:-5]
 
             if os.path.isfile(asset_path):
-                commands.append(
-                    'aws s3 cp {} s3://{}/{}'.format(
-                        asset_path,
-                        app.config['STORAGE_BACKEND']['asset_bucket'],
-                        app.config['STORAGE_BACKEND']['asset_s3path'].format(
-                            name=name_for_asset(
-                                os.path.relpath(asset_path, str(STATIC_ROOT)),
-                            ),
-                        ),
-                    ),
-                )
+                commands.append(build_command(asset_path))
 
     print('=' * 50)
     print('\n'.join(commands))


### PR DESCRIPTION
Proposed fix for https://github.com/chriskuehl/fluffy/issues/24.

This would require a new `asset_path` in the `STORAGE_BACKEND` dict.

Example `settings.py`:
```python
# fluffy-specific configuration options
# storage backend (how are the files stored after being uploaded?)
STORAGE_BACKEND = {
    'name': 'file',
    'object_path': 'tmp/object/{name}',
    'html_path': 'tmp/html/{name}',
    'asset_path': 'tmp/assets/{name}',
}

# branding
BRANDING = 'fluffy'
CUSTOM_FOOTER_HTML = None

# URL patterns
HOME_URL = 'http://localhost:5000/'
FILE_URL = 'http://localhost:4999/object/{name}'
HTML_URL = 'http://localhost:4999/html/{name}'

STATIC_ASSETS_URL = 'http://localhost:4999/assets/{name}'

# abuse contact email address
ABUSE_CONTACT = 'abuse@example.com'

# max upload size per request (in bytes)
MAX_UPLOAD_SIZE = 10 * 1048576  # 10 MB

# max size Flask will accept; maybe a little larger?
MAX_CONTENT_LENGTH = MAX_UPLOAD_SIZE * 10
```

and a diff with `settings/dev_files.py`:
```diff
diff --git i/settings/dev_files.py w/settings/dev_files.py
index 8fbe50d..8b080ab 100644
--- i/settings/dev_files.py
+++ w/settings/dev_files.py
@@ -4,6 +4,7 @@ STORAGE_BACKEND = {
     'name': 'file',
     'object_path': 'tmp/object/{name}',
     'html_path': 'tmp/html/{name}',
+    'asset_path': 'tmp/assets/{name}',
 }

 # branding
@@ -15,7 +16,7 @@ HOME_URL = 'http://localhost:5000/'
 FILE_URL = 'http://localhost:4999/object/{name}'
 HTML_URL = 'http://localhost:4999/html/{name}'

-STATIC_ASSETS_URL = 'http://localhost:5000/{name}'
+STATIC_ASSETS_URL = 'http://localhost:4999/assets/{name}'

 # abuse contact email address
 ABUSE_CONTACT = 'abuse@example.com'
```

I'm not sure if `settings/dev_files.py` should be updated, since the dev environment uses Flask to serve static assets. Perhaps it could go into a new `settings/prod_files.py`?